### PR TITLE
Allow to override default 'gpg' client

### DIFF
--- a/gemato/openpgp.py
+++ b/gemato/openpgp.py
@@ -15,6 +15,9 @@ import tempfile
 
 import gemato.exceptions
 
+GNUPG = os.environ.get('GNUPG', 'gpg')
+GNUPGCONF = os.environ.get('GNUPGCONF', 'gpgconf')
+
 
 class OpenPGPSignatureData(object):
     __slots__ = ['fingerprint', 'timestamp', 'expire_timestamp',
@@ -97,7 +100,7 @@ class OpenPGPSystemEnvironment(object):
         """
 
         exitst, out, err = self._spawn_gpg(
-            ['gpg', '--batch', '--status-fd', '1', '--verify'],
+            [GNUPG, '--batch', '--status-fd', '1', '--verify'],
             f.read().encode('utf8'))
         if exitst != 0:
             raise gemato.exceptions.OpenPGPVerificationFailure(err.decode('utf8'))
@@ -143,7 +146,7 @@ class OpenPGPSystemEnvironment(object):
         if keyid is not None:
             args += ['--local-user', keyid]
         exitst, out, err = self._spawn_gpg(
-            ['gpg', '--batch', '--clearsign'] + args,
+            [GNUPG, '--batch', '--clearsign'] + args,
             f.read().encode('utf8'))
         if exitst != 0:
             raise gemato.exceptions.OpenPGPSigningFailure(err.decode('utf8'))
@@ -154,10 +157,6 @@ class OpenPGPSystemEnvironment(object):
         env = os.environ.copy()
         env['TZ'] = 'UTC'
         env.update(env_override)
-
-        # Allow to override default 'gpg' client
-        if env.get('GNUPG', None):
-            argv[0] = env['GNUPG']
 
         try:
             p = subprocess.Popen(argv,
@@ -239,10 +238,10 @@ debug-level guru
     def close(self):
         if self._home is not None:
             ret, sout, serr = self._spawn_gpg(
-                ['gpgconf', '--kill', 'all'])
+                [GNUPGCONF, '--kill', 'all'])
             if ret != 0:
-                logging.warning('gpgconf --kill failed: {}'
-                                .format(serr))
+                logging.warning('{} --kill failed: {}'
+                                .format(GNUPGCONF, serr))
             if not self.debug:
                 # we need to loop due to ENOTEMPTY potential
                 while os.path.isdir(self._home):
@@ -255,7 +254,7 @@ debug-level guru
 
     def import_key(self, keyfile):
         exitst, out, err = self._spawn_gpg(
-            ['gpg', '--batch', '--import'], keyfile.read())
+            [GNUPG, '--batch', '--import'], keyfile.read())
         if exitst != 0:
             raise gemato.exceptions.OpenPGPKeyImportError(err.decode('utf8'))
 
@@ -266,7 +265,7 @@ debug-level guru
         """
         # list all keys in the keyring
         exitst, out, err = self._spawn_gpg(
-            ['gpg', '--batch', '--with-colons', '--list-keys'])
+            [GNUPG, '--batch', '--with-colons', '--list-keys'])
         if exitst != 0:
             raise gemato.exceptions.OpenPGPKeyRefreshError(err.decode('utf8'))
 
@@ -324,23 +323,23 @@ debug-level guru
         with self.clone() as subenv:
             # use --locate-keys to fetch keys via WKD
             exitst, out, err = subenv._spawn_gpg(
-                ['gpg', '--batch', '--locate-keys'] + list(addrs))
+                [GNUPG, '--batch', '--locate-keys'] + list(addrs))
             # if at least one fetch failed, gpg returns unsuccessfully
             if exitst != 0:
-                logging.debug('refresh_keys_wkd(): gpg --locate-keys failed: {}'
-                              .format(err.decode('utf8')))
+                logging.debug('refresh_keys_wkd(): {} --locate-keys failed: {}'
+                              .format(GNUPG, err.decode('utf8')))
                 return False
 
             # otherwise, xfer the keys
             exitst, out, err = subenv._spawn_gpg(
-                ['gpg', '--batch', '--export'] + list(keys))
+                [GNUPG, '--batch', '--export'] + list(keys))
             if exitst != 0:
-                logging.debug('refresh_keys_wkd(): gpg --export failed: {}'
-                              .format(err.decode('utf8')))
+                logging.debug('refresh_keys_wkd(): {} --export failed: {}'
+                              .format(GNUPG, err.decode('utf8')))
                 return False
 
             exitst, out, err = self._spawn_gpg(
-                ['gpg', '--batch', '--import', '--status-fd', '1'], out)
+                [GNUPG, '--batch', '--import', '--status-fd', '1'], out)
             if exitst != 0:
                 # there's no valid reason for import to fail here
                 raise gemato.exceptions.OpenPGPKeyRefreshError(err.decode('utf8'))
@@ -365,7 +364,7 @@ debug-level guru
             ks_args = ['--keyserver', keyserver]
 
         exitst, out, err = self._spawn_gpg(
-            ['gpg', '--batch', '--refresh-keys'] + ks_args)
+            [GNUPG, '--batch', '--refresh-keys'] + ks_args)
         if exitst != 0:
             raise gemato.exceptions.OpenPGPKeyRefreshError(err.decode('utf8'))
 

--- a/gemato/openpgp.py
+++ b/gemato/openpgp.py
@@ -155,6 +155,10 @@ class OpenPGPSystemEnvironment(object):
         env['TZ'] = 'UTC'
         env.update(env_override)
 
+        # Allow to override default 'gpg' client
+        if env.get('GNUPG', None):
+            argv[0] = env['GNUPG']
+
         try:
             p = subprocess.Popen(argv,
                                  stdin=subprocess.PIPE,

--- a/utils/gen_fast_metamanifest.py
+++ b/utils/gen_fast_metamanifest.py
@@ -72,7 +72,8 @@ def make_toplevel(d, ts, pgp_key):
 
             if pgp_key is not None:
                 cmd = []
-                p = subprocess.Popen(['gpg', '--batch', '-u', pgp_key,
+                gpg = os.environ.get('GNUPG', 'gpg')
+                p = subprocess.Popen([gpg, '--batch', '-u', pgp_key,
                                       '--armor', '--clearsign'],
                                      stdin=subprocess.PIPE,
                                      stdout=subprocess.PIPE,


### PR DESCRIPTION
The usecase here is to allow using [qubes-gpg-client](https://www.qubes-os.org/doc/split-gpg/) for signing manifest.

For reference: https://github.com/QubesOS/qubes-issues/issues/4412

Signed-off-by: Frédéric Pierret (fepitre) <frederic.pierret@qubes-os.org>